### PR TITLE
Prevent #NextLaunch countdown from taking timezone dropdown's focus

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -91,10 +91,10 @@
                 <countdown ng-if="substatistic.display == 'interval'" countdown-to="substatistic.result" specificity="7" type="interval"></countdown>
 
                 <div ng-if="substatistic.display == 'mission'">
-                    <launch-date launch-specificity="substatistic.result.launch_specificity" launch-date-time="substatistic.result.launch_date_time"></launch-date>
-
                     <countdown countdown-to="substatistic.result.launch_date_time" specificity="substatistic.result.launch_specificity" type="classic">
                     </countdown>
+					
+                    <launch-date launch-specificity="substatistic.result.launch_specificity" launch-date-time="substatistic.result.launch_date_time"></launch-date>
 
                     <div class="launch-link">
                         <a href="/missions/@{{ substatistic.result.slug }}">Go to Launch</a>


### PR DESCRIPTION
Fixes issue #39: 

![fixed screenshot](http://i.imgur.com/Kbhnxm1.png)

The location of the banner isn't moved. Only problem is on very short windows, the bar now overlays part of the countdown. Note that it overlapped before, but it was at least underneath the numbers. Would probably be best fixed by moving the whole banner up.

![short window fail](http://i.imgur.com/8cPgtgg.png)